### PR TITLE
small changes for better experience

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,17 @@ const infoContainer = document.querySelector(".info-container");
 const AudioContext = window.AudioContext || window.webkitAudioContext;
 const audioCtx = new AudioContext();
 
+document.querySelectorAll("*").forEach(e => {
+	e.addEventListener("contextmenu", e => {
+		e.stopPropagation()
+		e.preventDefault()
+	})
+	e.addEventListener("dragstart", e => {
+		e.stopPropagation()
+		e.preventDefault()
+	})
+})
+
 const sounds = {
 	pad1: new Audio(`${assetUrl}pad1.mp3`),
 	pad2: new Audio(`${assetUrl}pad2.mp3`),
@@ -110,9 +121,9 @@ const waitPlayerTurn = (waiting) => {
 		: [...pads].forEach((pad) => (pad.disabled = false));
 };
 
-btnStart.addEventListener("click", startNewGame);
+btnStart.addEventListener("mousedown", startNewGame);
 
-btnSound.addEventListener("click", () => {
+btnSound.addEventListener("mousedown", () => {
 	if (btnSound.classList.contains("mute")) {
 		btnSound.classList.remove(cls.mute);
 		isAudioMuted = false;
@@ -122,7 +133,7 @@ btnSound.addEventListener("click", () => {
 	}
 });
 
-padsContainer.addEventListener("click", (e) => {
+padsContainer.addEventListener("mousedown", (e) => {
 	if (e.target.classList.contains("pad")) {
 		handlePadClick(e);
 	}

--- a/styles.css
+++ b/styles.css
@@ -3,6 +3,7 @@
 * {
   box-sizing: border-box;
   will-change: all;
+  user-select: none;
 }
 
 html,


### PR DESCRIPTION
changing the `click` events to `mousedown` events to prevent fast mouse movement not being registered at times. disabling `contextmenu` aka right-click actions. disabling element drag to again prevent fast mouse movements not being registered. adding `user-select: none` to let users select nothing.